### PR TITLE
fix(api): use cache set method for empty search results

### DIFF
--- a/bases/ecoindex/backend/services/ecoindex.py
+++ b/bases/ecoindex/backend/services/ecoindex.py
@@ -44,8 +44,8 @@ async def get_latest_result_by_url(
     )
 
     if not ecoindexes:
-        await ecoindex_cache.set_cached_ecoindex_search_results(
-            ecoindex_search_results=EcoindexSearchResults(count=0).model_dump_json()
+        await ecoindex_cache.set(
+            data=EcoindexSearchResults(count=0).model_dump_json()
         )
 
         return EcoindexSearchResults(count=0)


### PR DESCRIPTION
Avoid a 500 error when no ecoindex results are found by storing the empty response with the cache API that actually exists.