### PR TITLE
fix(api): parameterize host count queries

### DIFF
--- a/components/ecoindex/database/repositories/ecoindex.py
+++ b/components/ecoindex/database/repositories/ecoindex.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import cast
 from uuid import UUID
 
 from ecoindex.database.helper import date_filter
@@ -30,7 +31,7 @@ async def get_count_analysis_db(
 
     result = await session.exec(statement)
 
-    return result.scalar_one()
+    return cast(int, result.one())
 
 
 async def get_rank_analysis_db(

--- a/components/ecoindex/database/repositories/ecoindex.py
+++ b/components/ecoindex/database/repositories/ecoindex.py
@@ -19,21 +19,16 @@ async def get_count_analysis_db(
     date_from: date | None = None,
     date_to: date | None = None,
 ) -> int:
-    statement = (
-        "SELECT count(*) FROM apiecoindex "
-        f"WHERE version = {version.get_version_number()}"
+    statement = select(func.count()).select_from(ApiEcoindex).where(
+        ApiEcoindex.version == version.get_version_number()
     )
 
     if host:
-        statement += f" AND host = '{host}'"
+        statement = statement.where(ApiEcoindex.host == host)
 
-    if date_from:
-        statement += f" AND date >= '{date_from}'"
+    statement = date_filter(statement=statement, date_from=date_from, date_to=date_to)
 
-    if date_to:
-        statement += f" AND date <= '{date_to}'"
-
-    result = await session.exec(statement=text(statement))  # type: ignore
+    result = await session.exec(statement)
 
     return result.scalar_one()
 

--- a/components/ecoindex/database/repositories/host.py
+++ b/components/ecoindex/database/repositories/host.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Any, cast
 
 from ecoindex.database.helper import date_filter
 from ecoindex.database.models import ApiEcoindex
@@ -25,7 +26,7 @@ async def get_host_list_db(
     )
 
     if host:
-        statement = statement.filter(ApiEcoindex.host.like(f"%{host}%"))  # type: ignore
+        statement = statement.filter(cast(Any, ApiEcoindex.host).like(f"%{host}%"))
 
     statement = date_filter(statement=statement, date_from=date_from, date_to=date_to)
 
@@ -53,7 +54,7 @@ async def get_count_hosts_db(
         statement = statement.where(ApiEcoindex.host == name)
 
     if q:
-        statement = statement.where(ApiEcoindex.host.like(f"%{q}%"))
+        statement = statement.where(cast(Any, ApiEcoindex.host).like(f"%{q}%"))
 
     statement = date_filter(statement=statement, date_from=date_from, date_to=date_to)
 
@@ -67,11 +68,13 @@ async def get_count_hosts_db(
         if name:
             count_statement = count_statement.where(ApiEcoindex.host == name)
         if q:
-            count_statement = count_statement.where(ApiEcoindex.host.like(f"%{q}%"))
+            count_statement = count_statement.where(
+                cast(Any, ApiEcoindex.host).like(f"%{q}%")
+            )
         count_statement = date_filter(
             statement=count_statement, date_from=date_from, date_to=date_to
         )
 
     result = await session.exec(count_statement)
 
-    return result.scalar_one()
+    return cast(int, result.one())

--- a/components/ecoindex/database/repositories/host.py
+++ b/components/ecoindex/database/repositories/host.py
@@ -3,7 +3,7 @@ from datetime import date
 from ecoindex.database.helper import date_filter
 from ecoindex.database.models import ApiEcoindex
 from ecoindex.models.enums import Version
-from sqlalchemy import text
+from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -45,26 +45,33 @@ async def get_count_hosts_db(
     date_to: date | None = None,
     group_by_host: bool = True,
 ) -> int:
-    sub_statement = (
-        f"SELECT host FROM apiecoindex WHERE version = {version.get_version_number()}"
+    statement = select(ApiEcoindex.host).where(
+        ApiEcoindex.version == version.get_version_number()
     )
+
     if name:
-        sub_statement += f" AND host = '{name}'"
+        statement = statement.where(ApiEcoindex.host == name)
 
     if q:
-        sub_statement += f" AND host LIKE '%{q}%'"
+        statement = statement.where(ApiEcoindex.host.like(f"%{q}%"))
 
-    if date_from:
-        sub_statement += f" AND date >= '{date_from}'"
-
-    if date_to:
-        sub_statement += f" AND date <= '{date_to}'"
+    statement = date_filter(statement=statement, date_from=date_from, date_to=date_to)
 
     if group_by_host:
-        sub_statement += " GROUP BY host"
+        statement = statement.group_by(ApiEcoindex.host)
+        count_statement = select(func.count()).select_from(statement.subquery())
+    else:
+        count_statement = select(func.count()).select_from(ApiEcoindex).where(
+            ApiEcoindex.version == version.get_version_number()
+        )
+        if name:
+            count_statement = count_statement.where(ApiEcoindex.host == name)
+        if q:
+            count_statement = count_statement.where(ApiEcoindex.host.like(f"%{q}%"))
+        count_statement = date_filter(
+            statement=count_statement, date_from=date_from, date_to=date_to
+        )
 
-    statement = f"SELECT count(*) FROM ({sub_statement}) t"
-
-    result = await session.exec(statement=text(statement))  # type: ignore
+    result = await session.exec(count_statement)
 
     return result.scalar_one()

--- a/test/components/ecoindex/database/test_repository_queries.py
+++ b/test/components/ecoindex/database/test_repository_queries.py
@@ -1,0 +1,59 @@
+import pytest
+from ecoindex.database.repositories.ecoindex import get_count_analysis_db
+from ecoindex.database.repositories.host import get_count_hosts_db
+from ecoindex.models.enums import Version
+
+
+class FakeResult:
+    def __init__(self, value: int):
+        self.value = value
+
+    def scalar_one(self) -> int:
+        return self.value
+
+
+class FakeSession:
+    def __init__(self, value: int = 1):
+        self.value = value
+        self.statement = None
+
+    async def exec(self, statement):
+        self.statement = statement
+        return FakeResult(self.value)
+
+
+@pytest.mark.asyncio
+async def test_get_count_analysis_db_parameterizes_host():
+    session = FakeSession()
+    host = "vivalya-reseau.com'"
+
+    count = await get_count_analysis_db(
+        session=session,
+        version=Version.v1,
+        host=host,
+    )
+
+    assert count == 1
+    assert session.statement is not None
+    compiled = session.statement.compile()
+    assert compiled.params["host_1"] == host
+    assert "vivalya-reseau.com''" not in str(compiled)
+
+
+@pytest.mark.asyncio
+async def test_get_count_hosts_db_parameterizes_exact_name():
+    session = FakeSession()
+    host = "vivalya-reseau.com'"
+
+    count = await get_count_hosts_db(
+        session=session,
+        version=Version.v1,
+        name=host,
+        group_by_host=False,
+    )
+
+    assert count == 1
+    assert session.statement is not None
+    compiled = session.statement.compile()
+    assert compiled.params["host_1"] == host
+    assert "vivalya-reseau.com''" not in str(compiled)

--- a/test/components/ecoindex/database/test_repository_queries.py
+++ b/test/components/ecoindex/database/test_repository_queries.py
@@ -8,7 +8,7 @@ class FakeResult:
     def __init__(self, value: int):
         self.value = value
 
-    def scalar_one(self) -> int:
+    def one(self) -> int:
         return self.value
 
 


### PR DESCRIPTION
Prevent SQL syntax errors when host filters contain quotes by replacing raw string interpolation with SQLAlchemy-built count queries.